### PR TITLE
Update plotly hover labels

### DIFF
--- a/prices/views.py
+++ b/prices/views.py
@@ -180,6 +180,8 @@ class GraphFormView(FormView):
         day_ahead = pd.Series(index=[a.date_time for a in p], data=[a.day_ahead for a in p])
         agile = day_ahead_to_agile(day_ahead, region=region).sort_index()
 
+        hover_template_time_price = "%{x|%H:%M}: %{y:.2f}p/kWh"
+
         data = data + [
             go.Scatter(
                 x=agile.loc[:forecast_end].index.tz_convert("GB"),
@@ -187,6 +189,7 @@ class GraphFormView(FormView):
                 marker={"symbol": 104, "size": 1, "color": "white"},
                 mode="lines",
                 name="Actual",
+                hovertemplate=hover_template_time_price
             )
         ]
 
@@ -216,7 +219,8 @@ class GraphFormView(FormView):
                         marker={"symbol": 104, "size": 10},
                         mode="lines",
                         line=dict(width=width),
-                        name=f.name,
+                        name="Prediction",
+                        hovertemplate=hover_template_time_price
                     )
                 ]
 
@@ -355,6 +359,7 @@ class GraphFormView(FormView):
             legend=legend,
             height=height,
             template="plotly_dark",
+            hovermode='x',
         )
 
         figure.update_layout(**layout)

--- a/prices/views.py
+++ b/prices/views.py
@@ -180,7 +180,8 @@ class GraphFormView(FormView):
         day_ahead = pd.Series(index=[a.date_time for a in p], data=[a.day_ahead for a in p])
         agile = day_ahead_to_agile(day_ahead, region=region).sort_index()
 
-        hover_template_time_price = "%{x|%H:%M}: %{y:.2f}p/kWh"
+        hover_template_time_price = "%{x|%H:%M}<br>%{y:.2f}p/kWh"
+        hover_template_price = "%{y:.2f}p/kWh"
 
         data = data + [
             go.Scatter(
@@ -189,7 +190,7 @@ class GraphFormView(FormView):
                 marker={"symbol": 104, "size": 1, "color": "white"},
                 mode="lines",
                 name="Actual",
-                hovertemplate=hover_template_time_price
+                hovertemplate=hover_template_price,
             )
         ]
 
@@ -220,7 +221,7 @@ class GraphFormView(FormView):
                         mode="lines",
                         line=dict(width=width),
                         name="Prediction",
-                        hovertemplate=hover_template_time_price
+                        hovertemplate=hover_template_price,
                     )
                 ]
 
@@ -234,6 +235,7 @@ class GraphFormView(FormView):
                             line=dict(width=1, color="red"),
                             name="Low",
                             showlegend=False,
+                            hovertemplate=hover_template_price
                         ),
                         go.Scatter(
                             x=df.index,
@@ -245,6 +247,7 @@ class GraphFormView(FormView):
                             showlegend=False,
                             fill="tonexty",
                             fillcolor="rgba(255,127,127,0.5)",
+                            hovertemplate=hover_template_price,
                         ),
                     ]
                 width = 1
@@ -381,8 +384,8 @@ class GraphFormView(FormView):
         )
         figure.update_xaxes(
             tickformatstops=[
-                dict(dtickrange=[None, 86000000], value="%H:%M\n%a %d %b"),
-                dict(dtickrange=[86000000, None], value="%a\n%b %d"),
+                dict(dtickrange=[None, 86000000], value="%H:%M<br>%a %d %b"),
+                dict(dtickrange=[86000000, None], value="%H:%M<br>%a %d %b"),
             ],
             # fixedrange=True,
         )


### PR DESCRIPTION
The hover-over labels on the price graphs had the default formatting which made the labels difficult to read, especially on mobile. This pull request formats some labels to look like `HH:mm: 20p/kWh`.

We also change the hovermode to 'x' which shows all column values within a certain distance from the hover. This is especially an improvement on mobile where it was difficult to select between the High, middle and Low predictions.

---

Before (Desktop):

![image](https://github.com/user-attachments/assets/e3bcc8bd-0270-4b88-bdca-21af99a0b71c)

After (Desktop):

![image](https://github.com/user-attachments/assets/4528b3c0-0dd6-4e79-b827-3d0b890beb46)

---

Before (Mobile):

![image](https://github.com/user-attachments/assets/39928af9-5552-4573-9465-9eccf637cfbd)


After (Mobile):

![image](https://github.com/user-attachments/assets/5c4068e1-ecd8-48ea-9b1a-1a0be4d2d926)

