### PR TITLE
Fix fresh-install forecast crash (#57, #61)

### DIFF
--- a/prices/management/commands/update.py
+++ b/prices/management/commands/update.py
@@ -661,6 +661,7 @@ class Command(BaseCommand):
                     refresh_db_connection("before loading training data")
                     fd = pd.DataFrame(list(ForecastData.objects.exclude(forecast_id__in=ignore_forecast).values()))
                     ff = pd.DataFrame(list(Forecasts.objects.exclude(id__in=ignore_forecast).values()))
+                    scores = None
 
                     if len(ff) > 0:
                         logger.info(ff)
@@ -1204,7 +1205,11 @@ class Command(BaseCommand):
 
                     refresh_db_connection("before saving forecast rows")
                     with transaction.atomic():
-                        this_forecast = Forecasts(name=new_name, mean=np.mean(scores), stdev=np.std(scores))
+                        if scores is not None:
+                            this_forecast = Forecasts(name=new_name, mean=np.mean(scores), stdev=np.std(scores))
+                        else:
+                            logger.info("No cross-validation scores available (no trained model yet); saving forecast without mean/stdev")
+                            this_forecast = Forecasts(name=new_name)
                         logger.info(f"Saving forecast record: {new_name}")
                         this_forecast.save()
                         fc["forecast"] = this_forecast
@@ -1221,5 +1226,7 @@ class Command(BaseCommand):
         else:
             try:
                 logger.info(f"\n\nAdded Forecast: {this_forecast.id:>4d}: {this_forecast.name}")
-            except:
-                logger.info("No forecast added")
+            except NameError:
+                logger.info("No forecast added (new_name already existed for this run)")
+            except Exception:
+                logger.exception("No forecast added due to an unexpected error")


### PR DESCRIPTION
## Summary
- `scores` was only assigned inside the `if len(ff) > 0` training branch of `manage.py update`, so on a fresh install (zero prior `Forecasts` rows) it stayed unbound while the forecast-save step referenced it unconditionally — crashing every first run with `UnboundLocalError: cannot access local variable 'scores'` (#57).
- That crash was also why a fresh install could never produce *any* forecast, even the placeholder all-null one the code already falls back to when no model has been trained yet (#61) — the crash happened before the save ever completed, so the install could never bootstrap the forecast history needed for real training to kick in on a later run.
- Replaced the bare `except:` around the "Added Forecast" log line, which was swallowing any exception (including this one) and just printing `"No forecast added"` with zero detail — it now distinguishes the expected case from unexpected failures and logs a full traceback for the latter.

Fixes #57. Addresses #61.

## Test plan
- [x] `ast.parse` on the modified file (syntax check)
- [ ] Verify on a genuinely empty DB that `manage.py update` completes without crashing and inserts a placeholder `Forecasts`/`ForecastData`/`AgileData` row
- [ ] Verify a subsequent run (once `ff` is non-empty) trains and predicts normally, unaffected by this change