### PR TITLE
Add /healthz endpoint and fly.io health check

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -27,6 +27,13 @@ console_command = '/code/manage.py shell'
   min_machines_running = 1
   processes = ['web']
 
+  [[http_service.checks]]
+    grace_period = '30s'
+    interval = '15s'
+    timeout = '10s'
+    method = 'GET'
+    path = '/healthz'
+
 [[vm]]
   memory = '1gb'
   cpu_kind = 'shared'

--- a/prices/urls.py
+++ b/prices/urls.py
@@ -16,6 +16,7 @@ from .views import (
     SiteLoginView,
     StatsV2View,
     StatsView,
+    healthz,
     run_latest_agile,
     run_update,
     stats_plot,
@@ -23,6 +24,7 @@ from .views import (
 )
 
 urlpatterns = [
+    path("healthz", healthz, name="healthz"),
     path("accounts/login/", SiteLoginView.as_view(), name="login"),
     path("accounts/register/", RegisterView.as_view(), name="register"),
     path("update", run_update, name="run_update"),

--- a/prices/views.py
+++ b/prices/views.py
@@ -279,6 +279,14 @@ def _scheduled_duplicate_response(request, job_type):
 
 
 @require_GET
+def healthz(request):
+    """Minimal liveness check for the fly.io health monitor: touches the DB but does
+    no heavy computation, so a genuinely wedged worker/DB still fails this fast."""
+    Forecasts.objects.exists()
+    return HttpResponse("OK")
+
+
+@require_GET
 def update_status(request):
     forbidden = _forbidden_if_update_token_invalid(request)
     if forbidden:


### PR DESCRIPTION
## Summary
- Production had two back-to-back outages today: gunicorn workers hanging the full 120s timeout on completely unrelated endpoints each time (an external-forecast comparison page, plain `/H/` history, and a bare `/api/A/` JSON route). No single slow external call explains all three — more consistent with general resource exhaustion on the `shared-cpu-1x`/1GB production machine.
- With only one web machine and no health check, fly.io had no way to detect or recover from this — both times required a manual `fly machine restart`.
- Added `/healthz`: a trivial DB-existence check (no heavy computation), so a genuinely wedged worker/DB still fails it quickly instead of masking the problem.
- Wired it into `fly.toml` as an `http_service` check (15s interval, 10s timeout, 30s grace period) so fly.io can detect and recycle a stuck machine automatically instead of requiring a manual restart.

This is a mitigation, not a root-cause fix — still need to dig into why unrelated requests are uniformly stalling (leading theory is CPU/memory pressure from the ML stack on a 1-CPU/1GB shared machine).

## Test plan
- [x] `ast.parse` on `views.py`/`urls.py`, `tomllib.load` on `fly.toml`
- [ ] Confirm `/healthz` returns 200 quickly once deployed
- [ ] Confirm fly.io shows the check as healthy in `fly status --app prices`