### PR TITLE
Fix /healthz DisallowedHost regression from #65

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -118,6 +118,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    "prices.middleware.HealthCheckMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",

--- a/prices/middleware.py
+++ b/prices/middleware.py
@@ -1,0 +1,21 @@
+from django.http import HttpResponse
+
+
+class HealthCheckMiddleware:
+    """Answer /healthz before any other middleware runs.
+
+    Fly.io's health-check prober hits this path using the machine's private
+    network address as the Host header, which Django's ALLOWED_HOSTS check
+    (triggered by CommonMiddleware/SecurityMiddleware) rejects with
+    DisallowedHost. That made the health check permanently "critical", so
+    Fly's proxy stopped routing any real traffic to the machine. Short-circuit
+    here, first in MIDDLEWARE, so the request never reaches host validation.
+    """
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        if request.path == "/healthz":
+            return HttpResponse("OK")
+        return self.get_response(request)


### PR DESCRIPTION
## Summary
The health check added in #65 caused a full production outage instead of preventing one: fly.io's prober hits `/healthz` using the machine's private-network IP as the `Host` header, which Django's `ALLOWED_HOSTS` validation rejects with `DisallowedHost` (triggered via `CommonMiddleware`/`SecurityMiddleware` calling `request.get_host()`). That made the check permanently "critical", and fly's proxy then refused to route **any** traffic to the machine at all — confirmed in prod logs (`django.security.DisallowedHost: Invalid HTTP_HOST header: '172.19.17.130:8000'` on every `/healthz` hit, followed by `proxy ... no known healthy instances found for route tcp/443`).

Fix: added `HealthCheckMiddleware` as the very first entry in `MIDDLEWARE`, so it answers `/healthz` directly before any middleware calls `get_host()` — the check never touches `ALLOWED_HOSTS` at all.

This needs to go out immediately; production is currently down because of #65's health check being permanently critical.

## Test plan
- [x] `ast.parse` on the changed files
- [ ] Deploy and confirm `fly status --app prices` shows the check passing
- [ ] Confirm real traffic (not just `/healthz`) is being routed again