### PR TITLE
Cap forecast days at 7 to test WORKER TIMEOUT mitigation

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -45,7 +45,7 @@ class PriceForecastRegionAPIView(generics.ListAPIView):
         context = super().get_serializer_context()
         context.update({"request": self.request})
         context.update({"region": self.kwargs["region"].upper()})
-        context.update({"days": int(self.request.query_params.get("days", 14))})
+        context.update({"days": min(max(int(self.request.query_params.get("days", 7)), 1), 7)})
         context.update({"high_low": self.request.query_params.get("high_low", "true").lower() in ["true", "1"]})
         context.update({"export": self.request.query_params.get("export", "false").lower() in ["true", "1", "yes", "on"]})
         return context

--- a/prices/views.py
+++ b/prices/views.py
@@ -1596,7 +1596,7 @@ class GraphV2View(V2NavMixin, TemplateView):
             region = "X"
         raw = _is_raw_day_ahead_region(region)
 
-        days = min(max(int(self.request.GET.get("days", 5)), 1), 14)
+        days = min(max(int(self.request.GET.get("days", 5)), 1), 7)
         show_band = self.request.GET.get("band", "1") != "0"
         show_export = self.request.GET.get("export", "0") == "1" and not raw
         show_gen = self.request.GET.get("gen", "1") == "1"


### PR DESCRIPTION
## Summary
- `GraphV2View` clamped `days` to 1-14; recurring `CRITICAL WORKER TIMEOUT` entries in prod keep landing on `days=14` requests (e.g. `/v2/G/?band=0&days=14&export=0&gen=1`).
- `api/views.py`'s `PriceForecastRegionAPIView` had **no upper bound at all** on `days` (default 14, but a client could pass anything) — also implicated in timeouts (`/api/A/?days=13&high_low=false`).
- Lowered both to a 1-7 day cap as a mitigation to test whether it resolves the recurring hang, per the pattern in the earlier `project_fly_timeouts` incident notes (large responses / slow `sendall`).

Test-and-see, not a confirmed root-cause fix — if timeouts persist even at days<=7, the issue is elsewhere (e.g. general resource exhaustion) and this should be reverted/revisited.

## Test plan
- [x] `ast.parse` on both changed files
- [ ] Deploy and monitor `fly logs` for `CRITICAL WORKER TIMEOUT` over the next few hours