### PR TITLE
Tighten forecast retention to 90 days (was 180)

### DIFF
--- a/prices/management/commands/update.py
+++ b/prices/management/commands/update.py
@@ -551,7 +551,7 @@ class Command(BaseCommand):
                 fail = " <- Fail"
             else:
                 fail = " <- Manual"
-                if days < max_days * 2:
+                if days < max_days:
                     for hour in [4, 6, 10, 11, 16, 22]:
                         if f"{hour:02d}:15" in f.name:
                             keep.append(f.id)


### PR DESCRIPTION
## Summary
Follow-up to #68. The user asked whether `prices_agiledata` retains data further back than training actually needs — yes: the scheduled cleanup in `update.py` kept forecasts for `max_days * 2` (180 days), but training only ever looks back `max_days` (90 days), and nothing else in the app reads more than 30 days of `AgileData`/`ForecastData` history (checked every `Timedelta(days=...)` window in `views.py`/`api/views.py` — the longest is the accuracy dashboard's 30 days).

Currently: oldest stored forecast is 129 days old (under the 180-day cutoff, so nothing's been deleted by age yet) — the table is still ramping toward a ~5.4M row steady state (180d x ~3 kept forecasts/day x ~9720 rows). Tightening to 90 days:
- Makes the 111 forecasts already older than 90 days (born Mar 1-Apr 9) eligible for deletion on the next scheduled run (not immediately — this only changes the cutoff, the next `manage.py update` run does the actual pruning as it always has).
- Caps future steady-state size at ~2.7M rows instead of ~5.4M.

## Test plan
- [x] `ast.parse` on the changed file
- [ ] Confirm the next scheduled `manage.py update` run logs the expected deletions
- [ ] Re-check `prices_agiledata` row count in a few days to confirm growth has capped