### PR TITLE
Reduce training/retention window from 90 to 60 days

### DIFF
--- a/prices/management/commands/update.py
+++ b/prices/management/commands/update.py
@@ -485,7 +485,7 @@ class Command(BaseCommand):
 
         min_fd = int(options.get("min_fd", 600) or 600)
         min_ad = int(options.get("min_ad", 1500) or 1500)
-        max_days = int(options.get("max_days", 90) or 90)
+        max_days = int(options.get("max_days", 60) or 60)
 
         no_ranges = options.get("no_ranges", False)
         skip_kde_plot = options.get("skip_kde_plot", False)


### PR DESCRIPTION
## Summary
Requested follow-up to #69. The scheduled `update` job's training/cross-validation step reads up to `max_days` of `ForecastData`/`AgileData` history, and we now have a direct correlation between running that job and a fresh outage (the site went down during a manually-triggered `update` run today, with DB CPU steal measurably worse than baseline during the run). Since retention is now tied to the same `max_days` value (per #69), lowering the default from 90 to 60 reduces both:
- the per-run training read volume
- the retained table size going forward

Only one call site (`prices/management/commands/update.py` line 488's default); `clean_forecasts.py`'s standalone `--max_days` default is unrelated (a separate manual admin command, defaults to effectively unlimited unless explicitly passed).

## Test plan
- [x] `ast.parse` on the changed file
- [ ] Confirm the next scheduled run uses 60 days and prunes accordingly
- [ ] Watch whether model accuracy is materially affected by the shorter training window