### PR TITLE
Restore 14-day forecast window; track monitoring scripts

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -45,7 +45,7 @@ class PriceForecastRegionAPIView(generics.ListAPIView):
         context = super().get_serializer_context()
         context.update({"request": self.request})
         context.update({"region": self.kwargs["region"].upper()})
-        context.update({"days": min(max(int(self.request.query_params.get("days", 7)), 1), 7)})
+        context.update({"days": min(max(int(self.request.query_params.get("days", 14)), 1), 14)})
         context.update({"high_low": self.request.query_params.get("high_low", "true").lower() in ["true", "1"]})
         context.update({"export": self.request.query_params.get("export", "false").lower() in ["true", "1", "yes", "on"]})
         return context

--- a/bin/uptime_monitor.sh
+++ b/bin/uptime_monitor.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# uptime_monitor.sh — poll prices.fly.dev every minute, log status/timing, and
+# push an ntfy.sh alert on DOWN/UP state transitions (not every failed check,
+# to avoid spam). Pure observation + alerting only — no restart action, so it
+# doesn't interact with watchdog.sh's hourly restart behavior.
+# Scheduled via cron: * * * * *
+
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+LOG="${SCRIPT_DIR}/../logs/uptime_monitor.log"
+STATE_FILE="${SCRIPT_DIR}/../logs/.uptime_state"
+URL="https://prices.fly.dev/"
+CURL_TIMEOUT=15
+NTFY_TOPIC="agile-predict-outage-7eef5967"
+
+result=$(curl -s -o /dev/null -w '%{http_code} %{time_total}' --max-time "$CURL_TIMEOUT" "$URL" 2>/dev/null || echo '000 0')
+code=$(echo "$result" | cut -d' ' -f1)
+now="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+
+printf '%s %s\n' "$now" "$result" >> "$LOG"
+
+if [[ "$code" =~ ^[23] ]]; then
+    current_state="up"
+else
+    current_state="down"
+fi
+
+prev_state="up"
+[ -f "$STATE_FILE" ] && prev_state="$(cat "$STATE_FILE")"
+
+if [ "$current_state" != "$prev_state" ]; then
+    if [ "$current_state" = "down" ]; then
+        curl -s -H 'Title: prices.fly.dev is DOWN' -H 'Priority: urgent' -H 'Tags: rotating_light'             -d "HTTP ${code} at ${now}" "https://ntfy.sh/${NTFY_TOPIC}" >/dev/null 2>&1 || true
+    else
+        curl -s -H 'Title: prices.fly.dev is back UP' -H 'Tags: white_check_mark'             -d "HTTP ${code} at ${now}" "https://ntfy.sh/${NTFY_TOPIC}" >/dev/null 2>&1 || true
+    fi
+    echo "$current_state" > "$STATE_FILE"
+fi

--- a/bin/uptime_report.sh
+++ b/bin/uptime_report.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# uptime_report.sh — summarize logs/uptime_monitor.log into outage episodes.
+# Usage: bin/uptime_report.sh [hours]   (default: all history)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+LOG="${SCRIPT_DIR}/../logs/uptime_monitor.log"
+HOURS="${1:-}"
+
+if [ -n "$HOURS" ]; then
+    CUTOFF=$(date -u -d "-${HOURS} hours" '+%Y-%m-%dT%H:%M:%SZ')
+    DATA=$(awk -v cutoff="$CUTOFF" '$1 >= cutoff' "$LOG")
+else
+    DATA=$(cat "$LOG")
+fi
+
+echo "$DATA" | awk '
+{
+    total++
+    code = $2
+    ok = (code ~ /^[23]/)
+    if (ok) { ok_count++ } else { fail_count++ }
+
+    if (!ok && !in_episode) {
+        in_episode = 1
+        episode_start = $1
+        episode_first_code = code
+    }
+    if (ok && in_episode) {
+        in_episode = 0
+        episodes++
+        printf "  Outage: %s -> %s (last_code=%s)\n", episode_start, prev_ts, prev_code
+    }
+    prev_ts = $1
+    prev_code = code
+}
+END {
+    if (in_episode) {
+        episodes++
+        printf "  Outage: %s -> ONGOING (last_code=%s)\n", episode_start, prev_code
+    }
+    print "---"
+    printf "Total checks: %d  OK: %d  Failed: %d  Uptime: %.2f%%\n", total, ok_count, fail_count, (total > 0 ? 100*ok_count/total : 0)
+    printf "Distinct outage episodes: %d\n", episodes
+}
+'

--- a/prices/views.py
+++ b/prices/views.py
@@ -1596,7 +1596,7 @@ class GraphV2View(V2NavMixin, TemplateView):
             region = "X"
         raw = _is_raw_day_ahead_region(region)
 
-        days = min(max(int(self.request.GET.get("days", 5)), 1), 7)
+        days = min(max(int(self.request.GET.get("days", 5)), 1), 14)
         show_band = self.request.GET.get("band", "1") != "0"
         show_export = self.request.GET.get("export", "0") == "1" and not raw
         show_gen = self.request.GET.get("gen", "1") == "1"


### PR DESCRIPTION
## Summary
Two small, unrelated cleanups from the same session:

1. **Restore 14-day forecast window.** The `days=7` cap (#67) was a mitigation attempt based on an unproven "large response" theory, disproven when timeouts recurred on `days=2`/`3` requests too. The real root cause (missing `AgileData` index) is fixed and confirmed (745ms sequential scan -> 37.5ms index scan). No reason to keep the shorter window.
2. **Track the outage-monitoring scripts in git.** `bin/uptime_monitor.sh`/`bin/uptime_report.sh` were created directly on the dev server and wired into crontab (every-minute poll of prices.fly.dev, logs to `logs/uptime_monitor.log`, ntfy.sh alert on down/up transitions). Adding them to version control since they were only living on disk. The crontab entry and ntfy.sh topic are already live — this commit doesn't change any running behavior, just tracks the scripts.

## Test plan
- [x] `ast.parse` on the changed Python files
- [x] Confirmed `days=14` requests are fast post-index-fix in prior testing
- [x] Monitoring scripts already verified working live on the dev server (manual test + confirmed automatic cron firing + ntfy alert round-trip)