### PR TITLE
Deploy: v2 Forecast overlap filter

### DIFF
--- a/prices/views.py
+++ b/prices/views.py
@@ -1736,6 +1736,10 @@ class GraphV2View(V2NavMixin, TemplateView):
         show_dc = self.request.GET.get("dc", "0") == "1"
         show_af = _truthy(self.request.GET.get("af", "")) and not raw
         show_x2r = _truthy(self.request.GET.get("x2r", "")) and not raw
+        # Draw forecasts for their full duration (back over the confirmed-price
+        # region) instead of trimming them at the last confirmed slot — mirrors
+        # v1's "Allow Forecast Overlap".
+        show_overlap = self.request.GET.get("overlap", "0") == "1"
         color_fn = _export_price_color if show_export else _price_color
 
         fc_param = self.request.GET.getlist("fc")
@@ -1767,6 +1771,12 @@ class GraphV2View(V2NavMixin, TemplateView):
             actual = pd.Series(dtype=float)
 
         actual_end = actual.index[-1] if not actual.empty else now_gb
+
+        # Lower bound for forecast series: normally the last confirmed slot (so
+        # forecasts don't overdraw confirmed prices); with overlap on, extend back
+        # to the chart's left edge so each forecast shows for its full duration.
+        fc_lower_gb = prior_gb if show_overlap else actual_end
+        fc_lower_utc = fc_lower_gb.tz_convert("UTC")
 
         # --- Forecasts ---
         recent_forecasts = list(Forecasts.objects.order_by("-created_at")[:8])
@@ -1800,8 +1810,7 @@ class GraphV2View(V2NavMixin, TemplateView):
 
         if latest is not None:
             if raw:
-                actual_end_utc = actual_end.tz_convert("UTC")
-                fd_rows = [r for r in fd_latest_rows if r["date_time"] >= actual_end_utc]
+                fd_rows = [r for r in fd_latest_rows if r["date_time"] >= fc_lower_utc]
                 if fd_rows:
                     primary_s = pd.Series(
                         index=pd.to_datetime([r["date_time"] for r in fd_rows]).tz_convert("GB"),
@@ -1812,7 +1821,7 @@ class GraphV2View(V2NavMixin, TemplateView):
                     AgileData.objects.filter(
                         forecast=latest,
                         region=region,
-                        date_time__gte=actual_end.tz_convert("UTC"),
+                        date_time__gte=fc_lower_utc,
                         date_time__lte=end_gb.tz_convert("UTC"),
                     ).order_by("date_time")
                 )
@@ -2273,7 +2282,7 @@ class GraphV2View(V2NavMixin, TemplateView):
                 od_rows = list(
                     ForecastData.objects.filter(
                         forecast=fc_obj,
-                        date_time__gte=actual_end.tz_convert("UTC"),
+                        date_time__gte=fc_lower_utc,
                         date_time__lte=end_gb.tz_convert("UTC"),
                     ).order_by("date_time")
                 )
@@ -2288,7 +2297,7 @@ class GraphV2View(V2NavMixin, TemplateView):
                     AgileData.objects.filter(
                         forecast=fc_obj,
                         region=region,
-                        date_time__gte=actual_end.tz_convert("UTC"),
+                        date_time__gte=fc_lower_utc,
                         date_time__lte=end_gb.tz_convert("UTC"),
                     ).order_by("date_time")
                 )
@@ -2527,6 +2536,7 @@ class GraphV2View(V2NavMixin, TemplateView):
                 "show_dc": show_dc,
                 "show_af": show_af,
                 "show_x2r": show_x2r,
+                "show_overlap": show_overlap,
                 "summary": summary,
                 "api_status": api_status,
                 "cheap_windows": cheap_windows,

--- a/templates/api_how_to_v2.html
+++ b/templates/api_how_to_v2.html
@@ -66,6 +66,7 @@
             dc      — dispatchable capacity, 1/0 (default 0)<br>
             af      — AgileForecast comparison overlay, 1/0 (default 0)<br>
             x2r     — X2R comparison overlay, 1/0 (default 0)<br>
+            overlap — draw forecasts over confirmed prices too, 1/0 (default 0)<br>
             fc      — forecast run id to plot; repeat to overlay several
           </div>
           <p style="font-size:.88rem" class="mb-1">Examples:</p>

--- a/templates/graph_v2.html
+++ b/templates/graph_v2.html
@@ -4,7 +4,7 @@
 <script>
 (function () {
   var KEY = 'ap_prefs_{{ region }}';
-  var PREF_KEYS = ['days','band','export','gen','dc','af','x2r'];
+  var PREF_KEYS = ['days','band','export','gen','dc','af','x2r','overlap'];
   var params = new URLSearchParams(window.location.search);
   var hasPrefs = PREF_KEYS.some(function(k){ return params.has(k); });
   if (!hasPrefs) {
@@ -162,7 +162,7 @@
       <span class="text-body-secondary" style="font-size:.72rem;white-space:nowrap">Period</span>
       <div class="btn-group btn-group-sm" role="group" aria-label="Days to show">
         {% for d in day_options %}
-        <a href="?days={{ d }}{% if not show_band %}&band=0{% endif %}{% if show_export %}&export=1{% endif %}{% if show_gen %}&gen=1{% endif %}{% if show_fc_gen %}&fg=1{% endif %}{% if show_dc %}&dc=1{% endif %}{% if show_af %}&af=1{% endif %}{% if show_x2r %}&x2r=1{% endif %}{% for id in selected_ids %}&fc={{ id }}{% endfor %}"
+        <a href="?days={{ d }}{% if not show_band %}&band=0{% endif %}{% if show_export %}&export=1{% endif %}{% if show_gen %}&gen=1{% endif %}{% if show_fc_gen %}&fg=1{% endif %}{% if show_dc %}&dc=1{% endif %}{% if show_af %}&af=1{% endif %}{% if show_x2r %}&x2r=1{% endif %}{% if show_overlap %}&overlap=1{% endif %}{% for id in selected_ids %}&fc={{ id }}{% endfor %}"
            class="btn {% if days == d %}btn-primary{% else %}btn-outline-secondary{% endif %}">{{ d }}d</a>
         {% endfor %}
       </div>
@@ -186,25 +186,30 @@
 
       {# Toggles #}
       {% if not is_raw_day_ahead_region %}
-      <a href="?days={{ days }}&band={% if show_band %}0{% else %}1{% endif %}{% if show_export %}&export=1{% endif %}{% if show_gen %}&gen=1{% endif %}{% if show_fc_gen %}&fg=1{% endif %}{% if show_dc %}&dc=1{% endif %}{% if show_af %}&af=1{% endif %}{% if show_x2r %}&x2r=1{% endif %}{% for id in selected_ids %}&fc={{ id }}{% endfor %}"
+      <a href="?days={{ days }}&band={% if show_band %}0{% else %}1{% endif %}{% if show_export %}&export=1{% endif %}{% if show_gen %}&gen=1{% endif %}{% if show_fc_gen %}&fg=1{% endif %}{% if show_dc %}&dc=1{% endif %}{% if show_af %}&af=1{% endif %}{% if show_x2r %}&x2r=1{% endif %}{% if show_overlap %}&overlap=1{% endif %}{% for id in selected_ids %}&fc={{ id }}{% endfor %}"
          class="btn btn-sm {% if show_band %}btn-outline-info active{% else %}btn-outline-secondary{% endif %}">
         Uncertainty band
       </a>
-      <a href="?days={{ days }}{% if not show_band %}&band=0{% endif %}&export={% if show_export %}0{% else %}1{% endif %}{% if show_gen %}&gen=1{% endif %}{% if show_fc_gen %}&fg=1{% endif %}{% if show_dc %}&dc=1{% endif %}{% if show_af %}&af=1{% endif %}{% if show_x2r %}&x2r=1{% endif %}{% for id in selected_ids %}&fc={{ id }}{% endfor %}"
+      <a href="?days={{ days }}{% if not show_band %}&band=0{% endif %}&export={% if show_export %}0{% else %}1{% endif %}{% if show_gen %}&gen=1{% endif %}{% if show_fc_gen %}&fg=1{% endif %}{% if show_dc %}&dc=1{% endif %}{% if show_af %}&af=1{% endif %}{% if show_x2r %}&x2r=1{% endif %}{% if show_overlap %}&overlap=1{% endif %}{% for id in selected_ids %}&fc={{ id }}{% endfor %}"
          class="btn btn-sm {% if show_export %}btn-outline-warning active{% else %}btn-outline-secondary{% endif %}">
         Export prices
       </a>
       {% endif %}
-      <a href="?days={{ days }}{% if not show_band %}&band=0{% endif %}{% if show_export %}&export=1{% endif %}&gen={% if show_gen %}0{% else %}1{% endif %}{% if show_fc_gen %}&fg=1{% endif %}{% if show_dc %}&dc=1{% endif %}{% if show_af %}&af=1{% endif %}{% if show_x2r %}&x2r=1{% endif %}{% for id in selected_ids %}&fc={{ id }}{% endfor %}"
+      <a href="?days={{ days }}{% if not show_band %}&band=0{% endif %}{% if show_export %}&export=1{% endif %}{% if show_gen %}&gen=1{% endif %}{% if show_fc_gen %}&fg=1{% endif %}{% if show_dc %}&dc=1{% endif %}{% if show_af %}&af=1{% endif %}{% if show_x2r %}&x2r=1{% endif %}&overlap={% if show_overlap %}0{% else %}1{% endif %}{% for id in selected_ids %}&fc={{ id }}{% endfor %}"
+         class="btn btn-sm {% if show_overlap %}btn-outline-info active{% else %}btn-outline-secondary{% endif %}"
+         title="Show each forecast for its full duration, including where a confirmed price now exists">
+        Forecast overlap
+      </a>
+      <a href="?days={{ days }}{% if not show_band %}&band=0{% endif %}{% if show_export %}&export=1{% endif %}&gen={% if show_gen %}0{% else %}1{% endif %}{% if show_fc_gen %}&fg=1{% endif %}{% if show_dc %}&dc=1{% endif %}{% if show_af %}&af=1{% endif %}{% if show_x2r %}&x2r=1{% endif %}{% if show_overlap %}&overlap=1{% endif %}{% for id in selected_ids %}&fc={{ id }}{% endfor %}"
          class="btn btn-sm {% if show_gen %}btn-outline-success active{% else %}btn-outline-secondary{% endif %}">
         Gen &amp; demand
       </a>
-      <a href="?days={{ days }}{% if not show_band %}&band=0{% endif %}{% if show_export %}&export=1{% endif %}{% if show_gen %}&gen=1{% endif %}{% if show_fc_gen %}&fg=1{% endif %}&dc={% if show_dc %}0{% else %}1{% endif %}{% if show_af %}&af=1{% endif %}{% if show_x2r %}&x2r=1{% endif %}{% for id in selected_ids %}&fc={{ id }}{% endfor %}"
+      <a href="?days={{ days }}{% if not show_band %}&band=0{% endif %}{% if show_export %}&export=1{% endif %}{% if show_gen %}&gen=1{% endif %}{% if show_fc_gen %}&fg=1{% endif %}&dc={% if show_dc %}0{% else %}1{% endif %}{% if show_af %}&af=1{% endif %}{% if show_x2r %}&x2r=1{% endif %}{% if show_overlap %}&overlap=1{% endif %}{% for id in selected_ids %}&fc={{ id }}{% endfor %}"
          class="btn btn-sm {% if show_dc %}btn-outline-warning active{% else %}btn-outline-secondary{% endif %}">
         Dispatch capacity
       </a>
       {% if show_gen and selected_ids %}
-      <a href="?days={{ days }}{% if not show_band %}&band=0{% endif %}{% if show_export %}&export=1{% endif %}&gen=1&fg={% if show_fc_gen %}0{% else %}1{% endif %}{% if show_dc %}&dc=1{% endif %}{% if show_af %}&af=1{% endif %}{% if show_x2r %}&x2r=1{% endif %}{% for id in selected_ids %}&fc={{ id }}{% endfor %}"
+      <a href="?days={{ days }}{% if not show_band %}&band=0{% endif %}{% if show_export %}&export=1{% endif %}&gen=1&fg={% if show_fc_gen %}0{% else %}1{% endif %}{% if show_dc %}&dc=1{% endif %}{% if show_af %}&af=1{% endif %}{% if show_x2r %}&x2r=1{% endif %}{% if show_overlap %}&overlap=1{% endif %}{% for id in selected_ids %}&fc={{ id }}{% endfor %}"
          class="btn btn-sm {% if show_fc_gen %}btn-outline-success active{% else %}btn-outline-secondary{% endif %}">
         Forecast inputs
       </a>
@@ -213,12 +218,12 @@
       {# External forecast overlays #}
       {% if not is_raw_day_ahead_region %}
       <div class="vr d-none d-sm-block" style="opacity:.3"></div>
-      <a href="?days={{ days }}{% if not show_band %}&band=0{% endif %}{% if show_export %}&export=1{% endif %}{% if show_gen %}&gen=1{% endif %}{% if show_fc_gen %}&fg=1{% endif %}{% if show_dc %}&dc=1{% endif %}&af={% if show_af %}0{% else %}1{% endif %}{% if show_x2r %}&x2r=1{% endif %}{% for id in selected_ids %}&fc={{ id }}{% endfor %}"
+      <a href="?days={{ days }}{% if not show_band %}&band=0{% endif %}{% if show_export %}&export=1{% endif %}{% if show_gen %}&gen=1{% endif %}{% if show_fc_gen %}&fg=1{% endif %}{% if show_dc %}&dc=1{% endif %}&af={% if show_af %}0{% else %}1{% endif %}{% if show_x2r %}&x2r=1{% endif %}{% if show_overlap %}&overlap=1{% endif %}{% for id in selected_ids %}&fc={{ id }}{% endfor %}"
          class="btn btn-sm"
          style="border-color:#D55E00;{% if show_af %}background:#D55E00;color:#fff{% else %}color:#D55E00{% endif %}">
         AgileForecast
       </a>
-      <a href="?days={{ days }}{% if not show_band %}&band=0{% endif %}{% if show_export %}&export=1{% endif %}{% if show_gen %}&gen=1{% endif %}{% if show_fc_gen %}&fg=1{% endif %}{% if show_dc %}&dc=1{% endif %}{% if show_af %}&af=1{% endif %}&x2r={% if show_x2r %}0{% else %}1{% endif %}{% for id in selected_ids %}&fc={{ id }}{% endfor %}"
+      <a href="?days={{ days }}{% if not show_band %}&band=0{% endif %}{% if show_export %}&export=1{% endif %}{% if show_gen %}&gen=1{% endif %}{% if show_fc_gen %}&fg=1{% endif %}{% if show_dc %}&dc=1{% endif %}{% if show_af %}&af=1{% endif %}&x2r={% if show_x2r %}0{% else %}1{% endif %}{% if show_overlap %}&overlap=1{% endif %}{% for id in selected_ids %}&fc={{ id }}{% endfor %}"
          class="btn btn-sm"
          style="border-color:#009E73;{% if show_x2r %}background:#009E73;color:#fff{% else %}color:#009E73{% endif %}">
         X2R
@@ -244,6 +249,7 @@
         {% if show_dc %}<input type="hidden" name="dc" value="1">{% endif %}
         {% if show_af %}<input type="hidden" name="af" value="1">{% endif %}
         {% if show_x2r %}<input type="hidden" name="x2r" value="1">{% endif %}
+        {% if show_overlap %}<input type="hidden" name="overlap" value="1">{% endif %}
         {% for f in forecast_list %}
         <div class="form-check form-check-inline mb-0">
           <input class="form-check-input" type="checkbox" name="fc" value="{{ f.id }}"


### PR DESCRIPTION
Adds the **Forecast overlap** filter to the v2 chart (`overlap` GET param + toggle button), mirroring v1's "Allow Forecast Overlap": forecasts are drawn for their full duration back over the confirmed-price region instead of being trimmed at the last confirmed slot.

- View: forecast series (primary + band + older selected runs, raw and agile) start at the chart's left edge when `overlap=1`; colour strip and summary stats unchanged.
- UI: toggle button (all regions), threaded through every filter/day link and the forecast-run form, remembered in localStorage prefs.
- Docs: added to the v2 URL-parameter table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)