### PR TITLE
Fix NESO CSV fallback dropping the time component, and the None-column crash

### DIFF
--- a/config/utils.py
+++ b/config/utils.py
@@ -626,13 +626,36 @@ def get_latest_history(start):
         return hist.astype(float).dropna(), missing_cols
 
 
-def _neso_csv_fallback(resource_id, date_col, cols, rename, tz="UTC"):
+# Minimum rows expected from a NESO source that publishes a full 14-day half-hourly
+# series (wind, solar, demand). Below this the source is treated as failed rather than
+# degraded: the CSV fallback is tried, and the status page reports it red. Day-ahead
+# sources (WINDFOR-DA, BMRS NDF) legitimately return far fewer rows and are exempt.
+NESO_MIN_FORECAST_ROWS = 200
+
+
+def _neso_csv_fallback(resource_id, spec):
     """
-    When the NESO CKAN datastore API returns empty, fetch the resource's CSV file
-    directly. Uses resource_show to get the canonical download URL so we don't
-    hard-code a path that can change.
+    When the NESO CKAN datastore API returns too little data, fetch the resource's
+    CSV file directly. Uses resource_show to get the canonical download URL so we
+    don't hard-code a path that can change.
+
+    `spec` is the same dataset definition the primary `DataSet` path uses, so the
+    fallback builds its index the same way. That matters: EMBSOLARFOR splits the
+    slot timestamp across DATE_GMT (always midnight) and TIME_GMT. An earlier
+    version of this function used date_col alone, so all 48 slots of a day
+    collapsed onto one timestamp and the de-duplication below silently discarded
+    47 of every 48 rows — a 14-day forecast arrived as 14 rows, the update aborted
+    on its own minimum-row guard, and the status page still reported "CSV backup"
+    as though the fallback had worked.
     """
     from io import StringIO
+
+    date_col = spec.get("date_col")
+    time_col = spec.get("time_col")
+    period_col = spec.get("period_col")
+    cols = spec.get("cols")
+    rename = spec.get("rename")
+    tz = spec.get("tz", "UTC")
 
     try:
         meta = requests.get(
@@ -658,6 +681,17 @@ def _neso_csv_fallback(resource_id, date_col, cols, rename, tz="UTC"):
         df.index = pd.to_datetime(df[date_col])
         if df.index.tzinfo is None:
             df.index = df.index.tz_localize(tz, ambiguous="infer")
+
+        # Add the intra-day offset, mirroring DataSet.download(). Without this a
+        # date-only column collapses every slot of a day onto midnight.
+        if time_col and time_col in df.columns:
+            df.index += (
+                pd.to_datetime(df[time_col].astype(str).str[:5], format="%H:%M")
+                - pd.Timestamp("1900-01-01")
+            )
+        elif period_col and period_col in df.columns:
+            df.index += (df[period_col].astype(int) - 1) * pd.Timedelta("30min")
+
         # Drop historical data we don't need — keep last 1 day + all future
         cutoff = pd.Timestamp.now(tz=tz) - pd.Timedelta("1D")
         df = df[df.index >= cutoff]
@@ -666,7 +700,16 @@ def _neso_csv_fallback(resource_id, date_col, cols, rename, tz="UTC"):
         if rename:
             df = df.set_axis(rename, axis=1)
         df = df.sort_index()
+        n_before_dedup = len(df)
         df = df[~df.index.duplicated()]
+        if n_before_dedup and len(df) < n_before_dedup / 2:
+            # Losing more than half the rows to duplicate timestamps means the index
+            # is not resolving to individual slots — the failure mode described above.
+            logger.warning(
+                "NESO CSV fallback: id=%s collapsed %s rows to %s unique timestamps — "
+                "check date_col/time_col for this resource",
+                resource_id, n_before_dedup, len(df),
+            )
         logger.info("NESO CSV fallback succeeded id=%s rows=%s", resource_id, len(df))
         return df, None
     except Exception as exc:
@@ -689,6 +732,7 @@ def get_latest_forecast():
             "cols": ["Wind_Forecast"],
             "rename": ["bm_wind"],
             "csv_fallback": "93c3048e-1dab-4057-a2a9-417540583929",
+            "min_rows": NESO_MIN_FORECAST_ROWS,
         },
         {
             "api_group": "neso_da_wind",
@@ -712,6 +756,7 @@ def get_latest_forecast():
             "date_col": "DATE_GMT",
             "time_col": "TIME_GMT",
             "csv_fallback": "db6c038f-98af-4570-ab60-24d71ebd0ae5",
+            "min_rows": NESO_MIN_FORECAST_ROWS,
         },
         {
             "api_group": "neso_demand",
@@ -722,6 +767,7 @@ def get_latest_forecast():
             "tz": "UTC",
             "cols": ["NATIONALDEMAND"],
             "csv_fallback": "7c0411cd-2714-4bb5-a408-adb065edf34d",
+            "min_rows": NESO_MIN_FORECAST_ROWS,
         },
         {
             "api_group": "openmeteo",
@@ -770,24 +816,31 @@ def get_latest_forecast():
         group = x.get("api_group", "other")
         label = x.get("label", group)
         csv_fallback_id = x.get("csv_fallback")
-        ds_kwargs = {k: v for k, v in x.items() if k not in ("api_group", "label", "csv_fallback")}
+        ds_kwargs = {
+            k: v for k, v in x.items()
+            if k not in ("api_group", "label", "csv_fallback", "min_rows")
+        }
         data, e = DataSet(**ds_kwargs).download()
         n = len(data)
 
-        # If the datastore API returned nothing, try CSV fallback
+        # If the datastore API returned nothing — or a short response, which is how a
+        # partial NESO outage presents — try the CSV fallback. `min_rows` is set only
+        # on the sources that are expected to carry a full 14-day half-hourly series;
+        # day-ahead sources legitimately return far fewer rows.
+        min_rows = x.get("min_rows", 0)
         used_csv_fallback = False
-        if n == 0 and csv_fallback_id:
-            logger.info("API returned no data for %s — trying CSV fallback", label)
-            data, e = _neso_csv_fallback(
-                csv_fallback_id,
-                ds_kwargs.get("date_col"),
-                ds_kwargs.get("cols"),
-                ds_kwargs.get("rename"),
-                ds_kwargs.get("tz", "UTC"),
+        if csv_fallback_id and n < max(min_rows, 1):
+            logger.info(
+                "API returned %s rows for %s (minimum %s) — trying CSV fallback",
+                n, label, max(min_rows, 1),
             )
-            n = len(data)
-            if n > 0:
+            fb_data, fb_e = _neso_csv_fallback(csv_fallback_id, ds_kwargs)
+            # Only take the fallback if it is actually better than what the API gave us.
+            if len(fb_data) > n:
+                data, e, n = fb_data, fb_e, len(fb_data)
                 used_csv_fallback = True
+            elif n == 0:
+                e = fb_e if fb_e is not None else e
 
         prev = source_details.get(group, {"label": label, "rows": 0, "error": None, "fallback": False})
         prev["rows"] += n
@@ -835,7 +888,7 @@ def get_latest_forecast():
     if len(gas_av) > 0:
         df["gas_availability"] = gas_av.reindex(df.index, method="ffill").bfill()
     else:
-        df["gas_availability"] = None
+        df["gas_availability"] = np.nan
 
     df["gas_ttf"] = gas_ttf_at(pd.Timestamp.now(tz="UTC"))
 
@@ -846,7 +899,7 @@ def get_latest_forecast():
         source_rows["rte_nuclear"] = int(fr_nuc.notna().sum())
         source_details["rte_nuclear"] = {"label": "ENTSO-E FR nuclear", "rows": source_rows["rte_nuclear"], "error": None, "fallback": False}
     else:
-        df["fr_nuclear"] = None
+        df["fr_nuclear"] = np.nan
         source_rows["rte_nuclear"] = 0
         source_details["rte_nuclear"] = {"label": "ENTSO-E FR nuclear", "rows": 0, "error": "no data", "fallback": False}
 
@@ -874,8 +927,8 @@ def get_latest_forecast():
         source_rows["neso_dc"]   = int(df["dispatchable_capacity"].notna().sum())
         source_details["neso_dc"] = {"label": "NESO Dispatch Cap.", "rows": source_rows["neso_dc"], "error": None, "fallback": False}
     else:
-        df["dispatchable_capacity"] = None
-        df["opmr_national_surplus"] = None
+        df["dispatchable_capacity"] = np.nan
+        df["opmr_national_surplus"] = np.nan
         source_rows["neso_dc"]   = 0
         source_details["neso_dc"] = {"label": "NESO Dispatch Cap.", "rows": 0, "error": "no data", "fallback": False}
 
@@ -888,7 +941,7 @@ def get_latest_forecast():
         source_rows["melngc"]   = int(df["melngc_margin"].notna().sum())
         source_details["melngc"] = {"label": "BMRS MELNGC", "rows": source_rows["melngc"], "error": None, "fallback": False}
     else:
-        df["melngc_margin"] = None
+        df["melngc_margin"] = np.nan
         source_rows["melngc"]   = 0
         source_details["melngc"] = {"label": "BMRS MELNGC", "rows": 0, "error": "no data", "fallback": False}
 
@@ -901,8 +954,8 @@ def get_latest_forecast():
         source_rows["openmeteo_fr"] = _fr_rows
         source_details["openmeteo_fr"] = {"label": "Open-Meteo FR", "rows": _fr_rows, "error": None, "fallback": False}
     else:
-        df["fr_wind"] = None
-        df["fr_rad"]  = None
+        df["fr_wind"] = np.nan
+        df["fr_rad"]  = np.nan
         source_rows["openmeteo_fr"] = 0
         source_details["openmeteo_fr"] = {"label": "Open-Meteo FR", "rows": 0, "error": "no data", "fallback": False}
 

--- a/prices/tests.py
+++ b/prices/tests.py
@@ -956,3 +956,136 @@ class SummaryPlacementTests(TestCase):
 
         self.assertEqual(_SUMMARY_POSITIONS, tuple(p for p, _ in _SUMMARY_POSITION_LABELS))
         self.assertEqual(_SUMMARY_POSITIONS[0], "above", "default must be first")
+
+
+class NesoCsvFallbackTests(TestCase):
+    """Regression tests for the 2026-08-25/26 production forecast failures.
+
+    Two independent defects took the forecast down on consecutive runs:
+      * EMBSOLARFOR's CSV fallback ignored TIME_GMT, so all 48 slots of a day
+        collapsed onto midnight and de-duplication discarded 47 of every 48 rows.
+        652 rows arrived as 14, and the update aborted on its minimum-row guard.
+      * When OPMR was unavailable, `dispatchable_capacity` was set to Python None,
+        producing an object-dtype column. LightGBM rejects those outright, so the
+        forecast died with an opaque dtype error instead of degrading.
+    """
+
+    def _csv_frame(self):
+        """Two days of half-hourly embedded forecast, shaped like the real CSV."""
+        rows = []
+        for day in ("2026-08-26", "2026-08-27"):
+            for slot in range(48):
+                hh, mm = divmod(slot * 30, 60)
+                rows.append({
+                    "DATE_GMT": f"{day}T00:00:00",
+                    "TIME_GMT": f"{hh:02d}:{mm:02d}",
+                    "EMBEDDED_SOLAR_FORECAST": 1000 + slot,
+                    "EMBEDDED_WIND_FORECAST": 500 + slot,
+                })
+        return pd.DataFrame(rows)
+
+    def _run_fallback(self, frame, spec):
+        from io import StringIO
+        from unittest.mock import MagicMock
+
+        import config.utils as utils
+
+        meta = MagicMock()
+        meta.json.return_value = {"result": {"url": "https://example.invalid/f.csv"}}
+        meta.raise_for_status.return_value = None
+        csv = MagicMock()
+        csv.text = frame.to_csv(index=False)
+        csv.raise_for_status.return_value = None
+
+        def _get(url, **kwargs):
+            return meta if "resource_show" in url else csv
+
+        with patch.object(utils, "requests") as req:
+            req.get.side_effect = _get
+            with patch.object(utils.pd.Timestamp, "now", return_value=pd.Timestamp("2026-08-26", tz="UTC")):
+                return utils._neso_csv_fallback("rid", spec)
+
+    def test_fallback_honours_time_col(self):
+        """The bug: without TIME_GMT the 96 rows collapse to 2 (one per day)."""
+        spec = {
+            "date_col": "DATE_GMT",
+            "time_col": "TIME_GMT",
+            "tz": "UTC",
+            "cols": ["EMBEDDED_SOLAR_FORECAST", "EMBEDDED_WIND_FORECAST"],
+            "rename": ["solar", "emb_wind"],
+        }
+        df, err = self._run_fallback(self._csv_frame(), spec)
+        self.assertIsNone(err)
+        self.assertEqual(len(df), 96, "every half-hourly slot must survive de-duplication")
+        self.assertEqual(list(df.columns), ["solar", "emb_wind"])
+        # Consecutive slots must be 30 minutes apart, not identical timestamps.
+        self.assertEqual((df.index[1] - df.index[0]), pd.Timedelta("30min"))
+
+    def test_fallback_without_time_col_is_unaffected(self):
+        """NATDEMAND carries a full timestamp in GDATETIME and must still work."""
+        frame = pd.DataFrame({
+            "GDATETIME": pd.date_range("2026-08-26", periods=48, freq="30min").strftime("%Y-%m-%dT%H:%M:%S"),
+            "NATIONALDEMAND": range(48),
+        })
+        df, err = self._run_fallback(frame, {"date_col": "GDATETIME", "tz": "UTC", "cols": ["NATIONALDEMAND"]})
+        self.assertIsNone(err)
+        self.assertEqual(len(df), 48)
+
+    def test_missing_optional_features_are_float_not_object(self):
+        """`= None` produces an object column that LightGBM refuses to predict on."""
+        import numpy as np
+
+        df = pd.DataFrame({"demand": [1.0, 2.0]})
+        df["dispatchable_capacity"] = np.nan
+        self.assertEqual(df["dispatchable_capacity"].dtype, float)
+
+        # The regression: the old code path used None.
+        legacy = pd.DataFrame({"demand": [1.0, 2.0]})
+        legacy["dispatchable_capacity"] = None
+        self.assertEqual(legacy["dispatchable_capacity"].dtype, object)
+
+    def test_ensemble_predicts_with_an_all_nan_feature(self):
+        """A missing optional feature must degrade, not crash the whole forecast."""
+        import numpy as np
+
+        cols = ["demand", "dispatchable_capacity"]
+        train_X = pd.DataFrame({"demand": np.arange(40.0), "dispatchable_capacity": np.arange(40.0) * 2})
+        train_y = pd.Series(np.arange(40.0) * 3)
+        models = fit_day_ahead_ensemble(train_X, train_y, np.ones(len(train_X)))
+
+        features = pd.DataFrame({"demand": [1.0, 2.0]})
+        features["dispatchable_capacity"] = np.nan
+        preds = predict_day_ahead_ensemble(models, features[cols])
+        self.assertEqual(len(preds), 2)
+        self.assertFalse(np.isnan(preds).any(), "ensemble must impute rather than emit NaN")
+
+
+class NesoSourceHealthTests(TestCase):
+    """A short response is a failure, not a degraded success."""
+
+    def _health(self, source_details):
+        from config.utils import NESO_MIN_FORECAST_ROWS
+
+        def _neso_sub_health(key):
+            d = source_details.get(key, {})
+            rows = d.get("rows", -1)
+            if rows < 0:
+                return "unknown"
+            if rows < NESO_MIN_FORECAST_ROWS:
+                return "fail"
+            return "warn" if d.get("fallback") else "ok"
+
+        return _neso_sub_health
+
+    def test_short_fallback_reports_fail_not_warn(self):
+        """The 14-row solar fallback previously showed amber 'CSV backup'."""
+        h = self._health({"neso_solar": {"rows": 14, "fallback": True}})
+        self.assertEqual(h("neso_solar"), "fail")
+
+    def test_full_fallback_still_reports_warn(self):
+        h = self._health({"neso_demand": {"rows": 624, "fallback": True}})
+        self.assertEqual(h("neso_demand"), "warn")
+
+    def test_full_direct_response_reports_ok(self):
+        h = self._health({"neso_wind": {"rows": 672, "fallback": False}})
+        self.assertEqual(h("neso_wind"), "ok")

--- a/prices/views.py
+++ b/prices/views.py
@@ -27,7 +27,7 @@ from django.views.generic import FormView, TemplateView
 from plotly.subplots import make_subplots
 
 from config.settings import GLOBAL_SETTINGS
-from config.utils import day_ahead_to_agile, import_agile_to_export_agile
+from config.utils import day_ahead_to_agile, import_agile_to_export_agile, NESO_MIN_FORECAST_ROWS
 
 from .external_forecasts import fetch_agileforecast, fetch_x2r, region_rows_from_g
 from .forms import ForecastForm, RegistrationForm
@@ -2582,7 +2582,7 @@ class GraphV2View(V2NavMixin, TemplateView):
         # --- API / data-source health status (binary: ok / fail, no amber) ---
         # NESO: minimum across the three 14-day sub-sources; da_wind excluded (supplementary)
         # BMRS NDF: day-ahead only, threshold is much lower
-        _NESO_THRESHOLD = 200   # rows below this → red for any primary NESO sub-source
+        _NESO_THRESHOLD = NESO_MIN_FORECAST_ROWS   # rows below this → red for any primary NESO sub-source
         _BMRS_THRESHOLD = 40    # NDF is day-ahead only; 40 rows ≈ one full day
 
         # Read source-row counts from the most recent UpdateJob (written there to survive
@@ -2620,12 +2620,19 @@ class GraphV2View(V2NavMixin, TemplateView):
             return "ok" if rows >= threshold else "fail"
 
         def _neso_sub_health(key):
-            """ok / warn (CSV backup used) / fail for a single NESO sub-source."""
+            """ok / warn (CSV backup used) / fail for a single NESO sub-source.
+
+            A short response is a failure, not a degraded success. This previously
+            tested only `rows == 0`, so a source that returned a handful of rows —
+            which is what a broken CSV fallback produces — was reported green, or
+            amber "CSV backup", while the update was actually aborting on its own
+            minimum-row guard.
+            """
             d = source_details.get(key, {})
             rows = d.get("rows", -1)
             if rows < 0:
                 return "unknown"
-            if rows == 0:
+            if rows < _NESO_THRESHOLD:
                 return "fail"
             return "warn" if d.get("fallback") else "ok"
 
@@ -2671,10 +2678,17 @@ class GraphV2View(V2NavMixin, TemplateView):
             label = d.get("label", group)
             rows = d.get("rows", -1)
             error = d.get("error")
+            _primary_neso = group in ("neso_wind", "neso_solar", "neso_demand")
+            _short = _primary_neso and 0 <= rows < _NESO_THRESHOLD
             if d.get("fallback"):
+                # Don't claim the backup worked when it returned too little to use.
+                if _short:
+                    return f"{label}: CSV backup incomplete ({rows} rows)"
                 return f"{label}: CSV backup"
             if error and rows == 0:
                 return f"{label}: {error}"
+            if _short:
+                return f"{label}: only {rows} rows"
             if rows >= 0:
                 return f"{label}: {rows} rows"
             return "no data"


### PR DESCRIPTION
Fixes #105. Production has failed three consecutive forecast runs (jobs 944, 945, 946); the last good forecast is 2026-08-25 15:15.

## Two independent defects

**1. The CSV fallback silently discarded 47 of every 48 rows.**
`_neso_csv_fallback` built its index from `date_col` alone. EMBSOLARFOR splits the slot timestamp across `DATE_GMT` (always midnight) and `TIME_GMT`, so every slot of a day collapsed onto one timestamp and the de-duplication step dropped the rest. Verified against the live resource: **652 rows arrive as 14**, and the update then aborts on its own 200-row guard. That is jobs 944 and 946.

The fallback now mirrors `DataSet.download()`, honouring `time_col` and `period_col`, and warns when de-duplication removes more than half the rows.

**2. A missing optional feature crashed the forecast instead of degrading it.**
When OPMR returned nothing, `df["dispatchable_capacity"] = None` produced an **object**-dtype column. `dispatchable_capacity` is in `_BASE`, so LightGBM rejected it at predict time with `pandas dtypes must be int, float or bool`. That is job 945.

All optional-feature fallbacks now assign `np.nan`. CatBoost and LightGBM handle NaN natively, and ExtraTrees is already wrapped in `_MedianImputedModel`.

## Also

- The CSV fallback now triggers on a **short** response, not only an empty one — a partial NESO outage previously bypassed it entirely. It only ever replaces the API data when it returns more rows.
- **The status page was reporting both failures as healthy.** `_neso_sub_health` tested only `rows == 0`, so a 14-row source displayed as amber "CSV backup" while the update was aborting. It now applies the same 200-row threshold as the rest of the page, shared as `config.utils.NESO_MIN_FORECAST_ROWS`, and the detail text distinguishes a working backup from an incomplete one.

## Testing

Tested on the CT dev server against the **live** NESO APIs, without persisting a forecast (that box is mid dynamic-range trial and its database is the trial's measurement set).

- Forcing the solar datastore to return empty — the exact 08-25 condition — now yields **652 rows via the fallback**, against 14 before.
- The solar API is failing *right now*: an unforced live run also came back via the fallback with 652 rows, so this fix resolves the current outage rather than only a historical one.
- No object-dtype columns in the feature frame; the ensemble predicts through an all-NaN feature.
- 7 new regression tests; full suite 86 tests, 1 failure (`test_history_view_ignores_region_url_and_uses_day_ahead`) which **fails identically on `main`** and is unrelated.

Branched from `main` rather than `dev` so it can ship without the dynamic-range trial work. `config/utils.py` and `prices/views.py` are identical on both branches, so it merges to `dev` cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)