### PR TITLE
Exclude the History download commands from the Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -23,3 +23,12 @@ catboost_info/
 
 # Local Django file cache (never ship into the image)
 .django_cache/
+
+# Dev-only: the History backfill. `History` holds three years of generation and
+# weather actuals, kept on the CT dev box so production's database stays small
+# (see docs/MODEL_DYNAMIC_RANGE.md). Excluding the commands from the image is the
+# guard: absent code cannot be run by any route — management command, import or
+# shell — on any branch, including a dev branch deployed by accident.
+# prices/tests.py asserts these entries are still here.
+prices/management/commands/backfill_history.py
+prices/management/commands/full_hist.py

--- a/prices/tests.py
+++ b/prices/tests.py
@@ -1089,3 +1089,41 @@ class NesoSourceHealthTests(TestCase):
     def test_full_direct_response_reports_ok(self):
         h = self._health({"neso_wind": {"rows": 672, "fallback": False}})
         self.assertEqual(h("neso_wind"), "ok")
+
+
+class DockerignoreGuardTests(TestCase):
+    """`History` is dev-only data. The guard that actually protects production is
+    absence: the commands that download it are excluded from the image, so they
+    cannot run there by any route, on any branch. That is a build-time mechanism
+    and easy to undo silently in an edit, so it is asserted here."""
+
+    EXCLUDED = [
+        "prices/management/commands/backfill_history.py",
+        "prices/management/commands/full_hist.py",
+    ]
+
+    def _dockerignore(self):
+        from django.conf import settings
+
+        path = Path(settings.BASE_DIR) / ".dockerignore"
+        self.assertTrue(path.exists(), ".dockerignore is missing")
+        return [ln.strip() for ln in path.read_text(encoding="utf-8").splitlines()]
+
+    def test_history_commands_are_excluded_from_the_image(self):
+        lines = self._dockerignore()
+        for entry in self.EXCLUDED:
+            self.assertIn(
+                entry, lines,
+                f"{entry} must stay in .dockerignore — it downloads History, which is "
+                "dev-only data (see docs/MODEL_DYNAMIC_RANGE.md)",
+            )
+
+    def test_excluded_paths_match_real_command_names(self):
+        """A stale path would exclude nothing and fail silently."""
+        from django.conf import settings
+
+        for entry in self.EXCLUDED:
+            target = Path(settings.BASE_DIR) / entry
+            if entry.endswith("backfill_history.py") and not target.exists():
+                continue  # dev-only command; absent on main, where the entry is still wanted
+            self.assertTrue(target.exists(), f"{entry} is listed but does not exist")


### PR DESCRIPTION
Closes a live gap on production.

## The problem

`full_hist.py` is present and **unguarded** in the running production image. `python manage.py full_hist` on prod today would download three years of generation history and write it to the production database. `History` is dev-only data, held on the CT so production's database stays small (see `docs/MODEL_DYNAMIC_RANGE.md`).

The runtime guard added on `dev` (`prices/environment.py`) does not fix this: it lives on `dev`, production runs `main`. A dev-side guard structurally cannot protect the deployed branch.

## The fix

Exclude the commands from the build context. Absent code cannot be run by any route — management command, import, or shell — on any branch, including a dev branch deployed by accident.

This matches the existing idiom rather than inventing a second one: `bin/` is excluded the same way, and I verified `/code/bin` does not exist in the running prod image, so the mechanism demonstrably works with `COPY . /code`.

`backfill_history.py` does not exist on `main`; the entry is listed anyway so a future merge from `dev` cannot ship it either.

## Tests

Two tests assert the entries survive future edits, since `.dockerignore` is a build-time mechanism that is easy to undo silently in an unrelated change. One checks the entries are present; the other checks the paths still match real command names, so a stale path can't exclude nothing and fail silently. Verified against this branch, where `backfill_history.py` is legitimately absent.

## Note

**Takes effect on the next deploy** — the running image is unchanged until then.

Also confirmed clean while checking: no data-sync path carries `History`. `export_incremental`/`import_incremental` handle only `AgileData`, `ForecastData`, `Forecasts`, `PriceHistory`; `sync_local` and `get_local` import the model but never move its rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)