### PR TITLE
Shed scanner traffic in nginx, before it reaches a gunicorn worker

### DIFF
--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -54,6 +54,63 @@ http {
 
     access_log /dev/stdout slow if=$is_slow;
 
+    # ---- Shedding scanner traffic before it reaches gunicorn -----------------
+    #
+    # 2026-08-31: ~4 hours of outages, 28% of uptime checks failing. Cause was a
+    # single IP running a WordPress/Laravel exploit scan at 10-17 requests/second
+    # across both machines. Every one was correctly denied — but by the Django
+    # blocklist middleware, so each junk request still consumed a gunicorn worker
+    # to produce its 403. With 4 sync workers on one shared vCPU that is enough to
+    # saturate the box.
+    #
+    # This is the same shape as the auto-refresh overload removed on 2026-08-05:
+    # the fix is to remove the load, not to add capacity. The Django blocklist
+    # stays as defence in depth; this just stops the traffic much earlier and much
+    # more cheaply.
+
+    # The real client. Behind Fly's proxy $remote_addr is the proxy itself, so
+    # rate limiting on it would lump every visitor into one bucket.
+    map $http_fly_client_ip $client_ip {
+        default $http_fly_client_ip;
+        ""      $remote_addr;
+    }
+
+    # Paths this application has never served. Answered with 444 (close without
+    # response) so a scanner gets nothing and we spend no worker on it.
+    map $request_uri $is_exploit_probe {
+        default                                                    0;
+        ~*^/+(?:[^/]+/)?wp-(?:json|admin|content|includes|login)    1;
+        ~*^/+(?:index|xmlrpc|wlwmanifest|shell|eval|config)\.php    1;
+        ~*^/+livewire/                                              1;
+        ~*^/+\.(?:env|git)                                          1;
+        ~*^/+(?:vendor|autoload|phpunit)/                           1;
+    }
+
+    # An empty key disables the limit for that request, which is how the
+    # endpoints that must never be throttled are exempted:
+    #   /healthz  — Fly's health check, every 15s; throttling it fails the machine
+    #   /update   — the EasyCron forecast trigger, which fires once and never
+    #               retries, so a throttled POST silently loses a whole cycle
+    #   /webhooks — Ko-fi payment callbacks
+    map $request_uri $limit_key {
+        default        $client_ip;
+        ~^/healthz     "";
+        ~^/update      "";
+        ~^/webhooks/   "";
+    }
+
+    # 2 r/s sustained with a burst of 30 is far above any human browsing pattern
+    # (a chart page load is a handful of requests) and far below the 10-17 r/s the
+    # scanner sustained. Each machine keeps its own zone, so the effective ceiling
+    # across the two is double these numbers.
+    limit_req_zone  $limit_key zone=perip:10m rate=2r/s;
+    limit_conn_zone $limit_key zone=connperip:10m;
+    limit_req_status  429;
+    limit_conn_status 429;
+
+    # Log rejections so the next incident can be measured rather than guessed at.
+    limit_req_log_level warn;
+
     upstream django {
         server unix:/run/gunicorn.sock fail_timeout=0;
     }
@@ -63,6 +120,17 @@ http {
         server_name _;
 
         location / {
+            # Cheapest possible answer to a scanner: no upstream, no response.
+            if ($is_exploit_probe) {
+                return 444;
+            }
+
+            # burst=30 nodelay: a legitimate burst is served immediately, and only
+            # sustained excess is rejected. Without nodelay nginx would queue the
+            # burst instead, holding connections open — the opposite of the point.
+            limit_req  zone=perip burst=30 nodelay;
+            limit_conn connperip 20;
+
             proxy_pass http://django;
 
             # Host must pass through unchanged: Django's ALLOWED_HOSTS checks

--- a/prices/tests.py
+++ b/prices/tests.py
@@ -1089,3 +1089,84 @@ class NesoSourceHealthTests(TestCase):
     def test_full_direct_response_reports_ok(self):
         h = self._health({"neso_wind": {"rows": 672, "fallback": False}})
         self.assertEqual(h("neso_wind"), "ok")
+
+
+class NginxScannerShieldTests(TestCase):
+    """The nginx-level shield added after the 2026-08-31 outage.
+
+    A single IP ran a WordPress/Laravel exploit scan at 10-17 req/s. Every request
+    was denied, but by Django middleware, so each one still consumed a gunicorn
+    worker to produce its 403 — enough to saturate one shared vCPU. nginx now
+    answers those paths with 444 and rate-limits per client IP, so the load never
+    reaches a worker.
+
+    These tests mirror the nginx regexes in Python. They cannot prove nginx's
+    matching, but they do catch the dangerous mistake: a pattern broad enough to
+    swallow a route this application actually serves.
+    """
+
+    import re as _re
+
+    EXPLOIT_PATTERNS = [
+        _re.compile(r"^/+(?:[^/]+/)?wp-(?:json|admin|content|includes|login)", _re.I),
+        _re.compile(r"^/+(?:index|xmlrpc|wlwmanifest|shell|eval|config)\.php", _re.I),
+        _re.compile(r"^/+livewire/", _re.I),
+        _re.compile(r"^/+\.(?:env|git)", _re.I),
+        _re.compile(r"^/+(?:vendor|autoload|phpunit)/", _re.I),
+    ]
+    NEVER_LIMITED = [
+        _re.compile(r"^/healthz"),
+        _re.compile(r"^/update"),
+        _re.compile(r"^/webhooks/"),
+    ]
+
+    def _blocked(self, path):
+        return any(p.search(path) for p in self.EXPLOIT_PATTERNS)
+
+    def _exempt(self, path):
+        return any(p.search(path) for p in self.NEVER_LIMITED)
+
+    def test_blocks_the_paths_actually_seen_in_the_attack(self):
+        for path in [
+            "/wp-json/batch/v1", "/wp-json/Batch/v1", "//wp-json/batch/v1",
+            "/wp-json/batch/v1/", "/blog/wp-json/batch/v1",
+            "/wp-json/gravitysmtp/v1/tests/mock-data",
+            "/index.php", "/livewire/update",
+            "/wp-admin/admin-ajax.php", "/.env", "/.git/config",
+            "/vendor/phpunit/phpunit/src/Util/PHP/eval-stdin.php",
+        ]:
+            self.assertTrue(self._blocked(path), f"{path} should be shed by nginx")
+
+    def test_never_blocks_a_route_this_site_serves(self):
+        for path in [
+            "/", "/healthz", "/update", "/api/", "/api/A/", "/api/accuracy/",
+            "/v2/X/", "/v2/X/?days=14&gen=1", "/v2/stats/", "/v2/history/",
+            "/v2/about/", "/v2/health/", "/v2/costs/", "/v2/model/",
+            "/webhooks/kofi/", "/webhooks/kofi/summary",
+            "/static/css/site.css", "/admin/", "/admin/login/",
+            "/accounts/login/", "/X/",
+        ]:
+            self.assertFalse(self._blocked(path), f"{path} is a real route and must not be shed")
+
+    def test_critical_endpoints_are_exempt_from_rate_limiting(self):
+        """These three cannot be throttled without breaking the service:
+        /healthz fails the machine, /update loses a forecast cycle outright
+        (EasyCron fires once and never retries), /webhooks/ drops payments."""
+        for path in ["/healthz", "/update", "/update?scheduled=1", "/webhooks/kofi/"]:
+            self.assertTrue(self._exempt(path), f"{path} must bypass the rate limit")
+
+    def test_ordinary_pages_are_not_exempt(self):
+        """Everything else must be limited, or the shield does nothing."""
+        for path in ["/", "/v2/X/", "/api/"]:
+            self.assertFalse(self._exempt(path))
+
+    def test_nginx_conf_still_contains_the_shield(self):
+        """Guards against the directives being dropped in an unrelated edit."""
+        from django.conf import settings
+
+        conf = (Path(settings.BASE_DIR) / "deploy" / "nginx.conf").read_text(encoding="utf-8")
+        for needle in ["limit_req_zone", "limit_conn_zone", "$is_exploit_probe",
+                       "return 444", "$limit_key", "$client_ip"]:
+            self.assertIn(needle, conf, f"nginx.conf lost {needle}")
+        self.assertIn("$http_fly_client_ip", conf,
+                      "rate limiting must key on the real client IP, not the Fly proxy")


### PR DESCRIPTION
## The incident

**2026-08-31: ~4 hours of outages, 28.4% of uptime checks failed** (0% on 22–27 Aug, so unrelated to the v145 deploy). The watchdog restarted the app three times, and the **15:15 UTC forecast cycle was lost** — EasyCron fires once and never retries, so an outage overlapping a slot silently drops it.

## Cause

A single IP, `45.148.10.12`, running a WordPress/Laravel exploit scan at **10–17 requests/second** across both machines — `/wp-json/batch/v1`, `/wp-json/gravitysmtp/…`, `/index.php`, `/livewire/update`, rotating user agents.

Every request was correctly denied. But the denial happens in the **Django blocklist middleware**, so each junk request still traversed fly proxy → nginx → **a gunicorn worker** → Django to produce its 403. With 4 sync workers on one shared vCPU, that saturates the box.

The wedge diagnostics fit: CPU pressure pinned at 100%, memory and IO pressure at zero, and only the listening socket with no pending connections.

## Fix

Move the denial in front of gunicorn. This is the same shape as the auto-refresh overload removed on 2026-08-05 — **remove the load, don't add capacity**.

- Never-served paths (`wp-json`, `wp-admin`, `*.php`, `livewire`, `.env`, `.git`, `vendor`) get **`return 444`** — connection closed, no upstream, no worker.
- **Per-IP rate limit, 2 r/s with burst 30**, `nodelay` so legitimate bursts are served immediately and only sustained excess is rejected. Far above any human browsing pattern; far below the scanner.
- Keyed on **`Fly-Client-IP`**, not `$remote_addr` — behind Fly's proxy the latter is the proxy itself, which would lump every visitor into one bucket.
- `limit_conn` 20 per IP as a slowloris backstop.

The Django blocklist stays as defence in depth; this just stops the traffic far earlier and far more cheaply.

## Exemptions — the part most likely to bite

Three endpoints bypass the limit via an empty limit key:

| path | why |
|---|---|
| `/healthz` | Fly's health check, every 15 s — throttling it fails the machine |
| `/update` | the EasyCron forecast trigger; it fires once and never retries, so a throttled POST loses an entire forecast cycle |
| `/webhooks/` | Ko-fi payment callbacks |

## Correcting an earlier reading

I initially read this as fly shared-CPU throttling and suggested a bigger VM. That was wrong, and would have meant buying capacity to absorb an attack. I also inferred "zero traffic" from an empty `nginx/access.log` — but this config only logs *slow* requests, and to stdout, so that file was never going to show anything.

## Testing

- Config validated with `nginx -t` (parse-only, in a container `/tmp`; the running config was untouched).
- 5 tests mirror the regexes in Python. They can't prove nginx's matching, but they catch the dangerous mistake — a pattern broad enough to swallow a route the site serves. They assert every attacked path is shed, that ~20 real routes (`/`, `/api/`, `/v2/…`, `/webhooks/kofi/`, `/admin/`, `/static/…`) are not, that the three critical endpoints are exempt, and that the directives survive future edits.

## Note

Takes effect on the next deploy. Worth pairing with #108, which is also inert until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)