### PR TITLE
Answer scanner probes with 403 rather than 444

### DIFF
--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -75,8 +75,17 @@ http {
         ""      $remote_addr;
     }
 
-    # Paths this application has never served. Answered with 444 (close without
-    # response) so a scanner gets nothing and we spend no worker on it.
+    # Paths this application has never served. Answered by nginx directly, so no
+    # gunicorn worker is spent on them.
+    #
+    # 403 rather than 444, changed 2026-08-31 after observing the deploy. 444
+    # closes without responding, which is the usual anti-scanner answer, but Fly's
+    # proxy sits in front of nginx and renders a closed connection as a 502 plus an
+    # error line of its own. At the 10-17 req/s this scanner sustained that is
+    # 10-17 proxy errors a second, which would bury genuine errors in the log —
+    # losing exactly the diagnosability that made this incident tractable. A 403 is
+    # a completed response, so the proxy stays quiet, and it costs nginx the same
+    # nothing.
     map $request_uri $is_exploit_probe {
         default                                                    0;
         ~*^/+(?:[^/]+/)?wp-(?:json|admin|content|includes|login)    1;
@@ -120,9 +129,9 @@ http {
         server_name _;
 
         location / {
-            # Cheapest possible answer to a scanner: no upstream, no response.
+            # Answered here, never proxied: no gunicorn worker is involved.
             if ($is_exploit_probe) {
-                return 444;
+                return 403;
             }
 
             # burst=30 nodelay: a legitimate burst is served immediately, and only

--- a/prices/tests.py
+++ b/prices/tests.py
@@ -1166,7 +1166,11 @@ class NginxScannerShieldTests(TestCase):
 
         conf = (Path(settings.BASE_DIR) / "deploy" / "nginx.conf").read_text(encoding="utf-8")
         for needle in ["limit_req_zone", "limit_conn_zone", "$is_exploit_probe",
-                       "return 444", "$limit_key", "$client_ip"]:
+                       "return 403", "$limit_key", "$client_ip"]:
             self.assertIn(needle, conf, f"nginx.conf lost {needle}")
         self.assertIn("$http_fly_client_ip", conf,
                       "rate limiting must key on the real client IP, not the Fly proxy")
+        self.assertNotIn("return 444", conf,
+                         "444 closes without responding, which Fly's proxy renders as a "
+                         "502 plus its own error line — 10-17 of them a second under a "
+                         "scan, burying real errors. Use 403.")


### PR DESCRIPTION
Follow-up to #110, from observing it in production on v146.

## What I saw

The shield works — scanner paths are shed by nginx and Django never sees them, confirmed in the logs. But they surface to the client as **502**, not a silent close, and each one produces a Fly proxy error line: **6 proxy errors for 6 test requests**.

`return 444` closes the connection without responding. That is the usual anti-scanner answer, but Fly's proxy sits in front of nginx and renders a closed connection as a gateway error of its own.

## Why it matters

At the 10–17 req/s this scanner sustained, that is 10–17 proxy errors per second in the log. It would bury genuine errors and lose exactly the diagnosability that made this incident tractable in the first place — the logs are how the cause was found.

## The change

`return 403` instead. A completed response, so the proxy stays quiet. It costs nginx the same nothing: still answered directly, still no gunicorn worker involved, still no upstream call.

No user impact either way — nobody legitimately requests `/wp-json/`.

## Testing

- `nginx -t` passed (parse-only, in a container `/tmp`; the running config untouched).
- The existing shield tests still pass, and the config test now also asserts `return 444` does **not** reappear, with the reason recorded — so the apparently-tidier option is not reintroduced later without the context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)