### PR TITLE
Disallow parameterised URLs in robots.txt

### DIFF
--- a/prices/tests.py
+++ b/prices/tests.py
@@ -1174,3 +1174,50 @@ class NginxScannerShieldTests(TestCase):
                          "444 closes without responding, which Fly's proxy renders as a "
                          "502 plus its own error line — 10-17 of them a second under a "
                          "scan, burying real errors. Use 403.")
+
+
+class RobotsCrawlerLoadTests(TestCase):
+    """robots.txt is the lever that keeps crawler sweeps off the workers.
+
+    2026-09-01: Bingbot swept chart query-parameter permutations. Each distinct
+    query string is its own cache entry, so every request was a miss and a full
+    re-render — measured 2.4-5.4s of CPU each. Four workers saturated, requests
+    queued to 24-47s, /healthz timed out with them and a machine went critical.
+    """
+
+    def _body(self):
+        return self.client.get("/robots.txt").content.decode()
+
+    def test_parameterised_urls_are_disallowed(self):
+        """The actual fix: the permutations are what cost, not the bare pages."""
+        self.assertIn("Disallow: /*?", self._body())
+
+    def test_api_is_disallowed(self):
+        """Large payloads, no indexing value."""
+        self.assertIn("Disallow: /api/", self._body())
+
+    def test_bare_pages_stay_indexable(self):
+        """A blanket Disallow: / for everyone would deindex the site. The chart
+        pages themselves are cheap once cached and carry the content worth finding."""
+        body = self._body()
+        wildcard = body.split("User-agent: *", 1)[1]
+        self.assertNotIn("Disallow: /\n", wildcard)
+
+    def test_bingbot_is_not_blocked_outright(self):
+        """Blocking Bingbot would remove the site from Bing for no extra
+        protection — the parameterised-URL rule already removes the load, and
+        covers the next crawler too."""
+        body = self._body()
+        for line in body.splitlines():
+            if line.lower().startswith("user-agent:"):
+                self.assertNotIn("bingbot", line.lower())
+
+    def test_known_ai_scrapers_still_blocked(self):
+        body = self._body()
+        for bot in ["GPTBot", "ClaudeBot", "CCBot", "PerplexityBot", "Bytespider"]:
+            self.assertIn(f"User-agent: {bot}", body)
+            
+    def test_served_without_authentication(self):
+        r = self.client.get("/robots.txt")
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r["Content-Type"], "text/plain")

--- a/prices/views.py
+++ b/prices/views.py
@@ -1752,10 +1752,31 @@ def robots_txt(request):
         "meta-externalagent",  # Meta AI
     ]
     lines = ["# AI scrapers that sweep every region/filter combination — blocked to"]
-    lines.append("# protect the app's 2 workers; the rate limiter backs this up.")
+    lines.append("# protect the app's gunicorn workers; the rate limiter backs this up.")
     for bot in blocked:
         lines += [f"User-agent: {bot}", "Disallow: /", ""]
-    lines += ["User-agent: *", "Crawl-delay: 10", "Disallow:", ""]
+
+    # 2026-09-01: Bingbot (msnbot-52-167-144-221.search.msn.com) was sweeping chart
+    # query-parameter permutations — /v2/A/?days=5&band=0&export=1&gen=0&dc=1&…
+    # Each distinct query string is a separate cache entry, so every one is a miss
+    # and a full re-render: measured 2.4-5.4s of CPU each. Four workers saturate
+    # almost immediately, requests queued to 24-47s, and /healthz timed out with
+    # them — one machine sat health-check critical for hours.
+    #
+    # Bingbot is NOT added to the block list above. Doing so would remove the site
+    # from Bing entirely, which is a real cost for no extra protection: the
+    # permutations are the problem, not the crawler. Disallowing parameterised URLs
+    # for everyone keeps the bare pages indexable while removing the load, and it
+    # covers the next crawler too rather than just this one.
+    lines += [
+        "# Parameterised URLs are per-combination cache misses, each a full re-render.",
+        "# The bare pages carry the same content and stay indexable.",
+        "User-agent: *",
+        "Crawl-delay: 10",
+        "Disallow: /*?",     # any URL with a query string
+        "Disallow: /api/",   # machine endpoint: large payloads, no indexing value
+        "",
+    ]
     return HttpResponse("\n".join(lines), content_type="text/plain")
 
 


### PR DESCRIPTION
## The problem

One web machine sat **health-check critical** for hours today, with ~8.6% of uptime checks failing.

This is **not** yesterday's scanner returning — that fix is working (0 `BLOCKLIST-DENY` reaching Django, 0 proxy errors). This is legitimate crawler traffic hitting genuinely expensive renders.

**Bingbot** (`msnbot-52-167-144-221.search.msn.com`) was sweeping chart query-parameter permutations:

```
47.5s  GET /v2/A/?days=5&band=0&export=1&gen=0&dc=1&overlap...
33.7s  GET /v2/X/?days=14&gen=1&x2r=1&summary=below
```

Every distinct query string is its own cache entry, so each request is a miss and a full re-render.

## Measured cost

Cold renders, timed in-process so queueing is excluded:

| endpoint | cold |
|---|---|
| `/v2/X/`, `/v2/A/` | **2.4–5.4 s** |
| `/api/H/` | 0.24–0.40 s |
| warm (cached) | 0.00–0.08 s |

So the endpoints are not pathologically slow — but at 2–5 s of CPU each, four workers saturate almost immediately. The 24–47 s figures in the slow log are queueing on top, and `/healthz` queued with them, which is why the machine went critical while the site still answered via its healthy twin.

## The fix

`Disallow: /*?` and `Disallow: /api/` for all agents.

**Bingbot is deliberately not blocked outright**, even though that was the obvious move and what I first proposed. It would remove the site from Bing entirely for no extra protection: the permutations are the problem, not the crawler. Disallowing parameterised URLs keeps the bare pages indexable, removes the load, and covers the next crawler rather than just this one.

Note the nginx rate limiter from #110 does not help here — at 2–5 s of CPU per request, even its 2 r/s allowance saturates four workers. Different problem, different lever.

## Testing

6 tests: the parameterised and `/api/` rules are present, the existing AI-scraper blocks survive, bare pages stay indexable (no blanket `Disallow: /` under the wildcard), and Bingbot is asserted **not** to be blocked outright — with the reason recorded, so the tempting shortcut is not taken later without the context.

Full suite passes (only the pre-existing `test_history_view_ignores_region_url_and_uses_day_ahead` failure, which fails on `main` too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)