### PR TITLE
History window: run to the end of confirmed pricing, not to 'now'

### DIFF
--- a/prices/tests.py
+++ b/prices/tests.py
@@ -215,6 +215,66 @@ class HistoryViewTests(TestCase):
         self.assertContains(response, "1 predictions for &lt;1d ahead")
 
 
+class HistoryDateWindowTests(TestCase):
+    """The rolling windows (Last Week / 2 Weeks / Month) must run to the end of
+    confirmed pricing, not stop dead at "now". Agile prices are published ahead
+    of time (release 16:00 for the next day), so PriceHistory routinely already
+    holds settled rows beyond the current moment — capping the window at `now`
+    hid prices the site already knew for no reason. Shared by both /history/
+    (v1) and /v2/history/ via HistoryView.get_date_window; HistoryV2View does
+    not override it."""
+
+    def test_window_extends_to_a_future_confirmed_price(self):
+        future = timezone.now() + timedelta(hours=20)
+        PriceHistory.objects.create(date_time=future, agile=0, day_ahead=100)
+
+        response = self.client.get("/history/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["custom_end_date"], future.date().isoformat())
+
+    def test_v2_history_also_extends(self):
+        future = timezone.now() + timedelta(hours=20)
+        PriceHistory.objects.create(date_time=future, agile=0, day_ahead=100)
+
+        response = self.client.get("/v2/history/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["custom_end_date"], future.date().isoformat())
+
+    def test_window_does_not_regress_without_future_data(self):
+        """Without a future-dated confirmed price the window still ends at
+        "now" as before — the fix must not always jump forward."""
+        response = self.client.get("/history/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["custom_end_date"], timezone.now().date().isoformat())
+
+    def test_custom_window_is_unaffected(self):
+        """An explicit custom date range is the user's own choice and must not
+        be silently extended past what they asked for."""
+        future = timezone.now() + timedelta(hours=20)
+        PriceHistory.objects.create(date_time=future, agile=0, day_ahead=100)
+        yesterday = (timezone.now() - timedelta(days=1)).date().isoformat()
+        today = timezone.now().date().isoformat()
+
+        response = self.client.get(f"/history/?window=custom&start_date={yesterday}&end_date={today}")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["custom_end_date"], today)
+
+    def test_future_confirmed_price_appears_in_the_chart_data(self):
+        """Not just the date-picker default — the extra confirmed row must
+        actually reach the query that builds the chart/table."""
+        future = timezone.now() + timedelta(hours=20)
+        PriceHistory.objects.create(date_time=future, agile=0, day_ahead=123.45)
+
+        response = self.client.get("/history/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["actual_count"], 1)
+
+
 class ExportPricingTests(TestCase):
     def test_national_export_coefficients_are_arithmetic_mean(self):
         regional_factors = [

--- a/prices/views.py
+++ b/prices/views.py
@@ -635,7 +635,16 @@ class HistoryView(TemplateView):
         if window_key not in self.window_options:
             window_key = "last-2-weeks"
 
-        end = timezone.now()
+        # Confirmed (settled) Agile prices are published ahead of "now" — the
+        # release time is 16:00 for the next day — so PriceHistory routinely
+        # already holds rows beyond the current moment. Capping the rolling
+        # windows at timezone.now() hid those already-known prices from the
+        # chart and the accuracy table for no reason; run to whichever is later.
+        now = timezone.now()
+        latest_confirmed = (
+            PriceHistory.objects.order_by("-date_time").values_list("date_time", flat=True).first()
+        )
+        end = max(now, latest_confirmed) if latest_confirmed else now
         start = end - timedelta(days=self.window_options[window_key]["days"] or 14)
         custom_start_date = start.date().isoformat()
         custom_end_date = end.date().isoformat()


### PR DESCRIPTION
## The bug

`HistoryView.get_date_window()` capped the rolling windows (Last Week / 2 Weeks / Month) at `timezone.now()`. But Agile prices are published ahead of time — release is 16:00 for the next day — so `PriceHistory` routinely already holds settled rows beyond the current moment. Capping at `now` hid those already-known prices from both the price chart and the accuracy table for no reason.

## The fix

```python
end = max(now, latest_confirmed) if latest_confirmed else now
```

Only ever extends the window, never shrinks it. The custom date-range option is untouched — an explicit user-chosen range must not be silently extended past what they asked for.

Verified live on the dev server: with today at 2026-09-03, the default end-date picker moved from `2026-09-03` to `2026-09-04`, matching that tomorrow's Agile prices were already published at the time.

Shared by `/history/` (v1) and `/v2/history/` (v2) via `HistoryView.get_date_window` — `HistoryV2View` doesn't override it, so one change fixes both.

## Testing

5 new tests: the window extends when a future-dated confirmed price exists (checked on both v1 and v2), it does *not* regress when there's no future data, the custom window is unaffected, and the extra row actually reaches the chart/table query (not just the date-picker default). Full suite: 104 tests, 1 pre-existing unrelated failure (`test_history_view_ignores_region_url_and_uses_day_ahead`, fails identically on `main` before this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)